### PR TITLE
 Convert every alias -g to plain alias 

### DIFF
--- a/zshrc_alias
+++ b/zshrc_alias
@@ -1,27 +1,24 @@
 # new aliases
 
-alias -g ll="ls -lahG"
-alias -g ls='ls -1'
-alias -g home='cd ~'
-alias -g up='cd ..'
-alias -g h='history'
+alias ll='command ls -lahG'
+alias ls='ls -1'
+alias home='cd ~'
+alias up='cd ..'
+alias h='history'
 
 # command option aliases
-# alias -g mv='mv -iv'
-# alias -g cp='cp -iv'
-# alias -g rm='rm -iv'
-alias -g df='df -h'
-alias -g du='du -h'
-alias -g mkdir='mkdir -p'
-alias -g diffy='diff -y --suppress-common-lines --width=250'
-alias -g showFiles='defaults write com.apple.finder AppleShowAllFiles YES; killall Finder /System/Library/CoreServices/Finder.app'
-alias -g hideFiles='defaults write com.apple.finder AppleShowAllFiles NO; killall Finder /System/Library/CoreServices/Finder.app'
-alias -g brewUp='brew update && brew upgrade && brew doctor && brew cleanup'
-alias -g treeL='tree -RapugD --si --du'
-alias -g ga="git add"
-alias -g gaa="git add --all"
-alias -g gc="git commit"
-alias -g gcc="git commit --all"
-alias -g gst="git status"
-alias -g text='open -a textedit'
-alias -g code='open -a VSCodium'
+alias df='df -h'
+alias du='du -h'
+alias mkdir='mkdir -p'
+alias diffy='diff -y --suppress-common-lines --width=250'
+alias showFiles='defaults write com.apple.finder AppleShowAllFiles YES; killall Finder'
+alias hideFiles='defaults write com.apple.finder AppleShowAllFiles NO; killall Finder'
+alias brewUp='brew update && brew upgrade && brew doctor && brew cleanup'
+alias treeL='tree -RapugD --si --du'
+alias ga="git add"
+alias gaa="git add --all"
+alias gc="git commit"
+alias gcc="git commit --all"
+alias gst="git status"
+alias text='open -a textedit'
+alias code='open -a VSCodium'

--- a/zshrc_functions
+++ b/zshrc_functions
@@ -1,49 +1,48 @@
 # functions
 
-	# brew reinstall nmaahcmm
+# brew reinstall nmaahcmm
 function nmaahcmm () {
 	brew reinstall nmaahcmm
 }
 
-# functions
-	# brew reinstall bashrc
+# brew reinstall zshrc
 function nmaahczshrc () {
 	brew reinstall zshrc
 }
 
-	# make directories named after files
+# make directories named after files in the current dir
 function makedirfile () {
 	for file in *.*; do
-    mkdir -p "${file%.*}";
-done
+		mkdir -p "${file%.*}"
+	done
 }
 
-	# rsync transfer for DAMS uploads
+# rsync transfer for DAMS uploads
 function rsyncDAMS () {
 	rsync -avvPhi --no-p --stats "${@}"
 }
 
-	# general rsync transfer
+# general rsync transfer
 function rsyncT () {
 	rsync -avvPhi --stats "${@}"
 }
 
-	# general rsync transfer with deletion of source files
+# general rsync transfer with deletion of source files
 function rsyncD () {
 	rsync -avvPhi --remove-source-files --stats "${@}"
 }
 
-	# remove hidden files from a location
+# remove hidden files/dirs from a location (does not delete the location itself)
 function removehidden () {
 	if [ -z "${1}" ] ; then
 		cowsay "no argument provided. tootles."
 	else
-		find "${1}" -name ".*" -exec rm -vfr {} \;
+		find "${1}" -name '.?*' -prune -exec rm -rf {} +
 		cowsay "hidden files removed. tootles."
 	fi
 }
 
-	# sort text in a file by column 2 and overwrite file ; column separator is a space.
+# sort text in a file by column 2 and overwrite file ; column separator is a space.
 function sortk2 () {
 	if [ -z "${1}" ]; then
 		cowsay "no argument provided. tootles."
@@ -53,7 +52,7 @@ function sortk2 () {
 	fi
 }
 
-function shortinfo() {
-   mediainfo --Inform="General;FileName=%FileNameExtension%,FileSize=%FileSize%,Duration(ms),%Duration%\n" "${@}";
-   mediainfo --Inform="Video;Width=%Width%,Height=%Height%,Codec=%CodecID%\n" "${@}";
+function shortinfo () {
+	mediainfo --Inform="General;FileName=%FileNameExtension%,FileSize=%FileSize%,Duration(ms),%Duration%\n" "${@}"
+	mediainfo --Inform="Video;Width=%Width%,Height=%Height%,Codec=%CodecID%\n" "${@}"
 }


### PR DESCRIPTION
   None of them benefit from mid-command expansion. Fix `ll`/`ls` collision via `command ls`, drop the
   spurious Finder.app arg from `showFiles`/`hideFiles` `killall`, and rewrite
   `removehidden` find to use `.?*` + -prune so it doesn't try to delete
   the starting directory or descend into dirs being removed. Normalize
   indentation and stale comments in `zshrc_functions`.